### PR TITLE
Pequeñas mejoras usabilidad

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -328,7 +328,7 @@ class _HomeScreenState extends State<HomeScreen> {
     }
 
     FloatingActionButton? floatingActionButton() {
-      if (currentTab == 0) {
+      if (currentTab == 3) {
         return FloatingActionButton(
           onPressed: () {
             setState(() => isFirstLaunch = false);
@@ -338,7 +338,7 @@ class _HomeScreenState extends State<HomeScreen> {
         );
       }
 
-      if (currentTab == 1) {
+      if (currentTab == 0) {
         return FloatingActionButton(
           onPressed: () {
             Navigator.push(


### PR DESCRIPTION
Como usuario diario de esta App, subo algunos cambios que echo de menos.

1.  Acceso a `grafico_precios` desde la pantalla principal. Me parece más útil que tener el botón de recargar datos para el día, el cuál muevo a la última pantalla.
2. En `grafico_precios`: Resaltar barra de la hora seleccionada. Además, se aumenta área en la que se puede tocar una barra, y se mantiene resaltada al dejar de tocar.
3. Aumentar tamaño del tooltip para que se pueda leer mejor.

![Screenshot_20250416-090302_Tarifa_luz 1](https://github.com/user-attachments/assets/ba967e6c-715e-49bb-807c-aa4f81d8e3f3)
